### PR TITLE
Allow specifying user ID and user type in the URL, aka "authentication" 

### DIFF
--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
   } = await req.json()
   console.log(`[CampusAssistant] User message: ${input.message}`)
 
-  // not doing any validation here for now
+  // not doing any validation here for now; we should add it when we have more than one user type
   let userType: CorporateServeUserType = input.data.userType || "student"
   const userID = input.data.userID || null
   console.log(`[CampusAssistant] UserType: ${userType} UserID: ${userID}`)

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -36,6 +36,17 @@ async function callCorpoAPI(oDataQuery: string): Promise<any> {
   }
 }
 
+function constructUserInstructions(userType: CorporateServeUserType, userID: string | null): string {
+  const userTypeUppercase = userType.toUpperCase()
+  if (!userID) {
+    return ""
+  }
+
+  return `\n
+${userTypeUppercase} DETAILS TO USE IN YOUR QUERIES:\n
+${userType} ID = ${userID}\n`
+}
+
 export async function POST(req: Request) {
   // Parse the request body
   const input: {
@@ -96,7 +107,8 @@ export async function POST(req: Request) {
               process.env.ASSISTANT_ID ??
               (() => {
                 throw new Error('ASSISTANT_ID is not set')
-              })()
+              })(),
+            additional_instructions: constructUserInstructions(userType, userID)
           },
           { signal: req.signal }
         )

--- a/app/api/assistant/route.ts
+++ b/app/api/assistant/route.ts
@@ -3,6 +3,7 @@ import { AssistantResponse } from 'ai'
 import OpenAI from 'openai'
 import APIClient from '../api_client'
 import { AssistantStream } from 'openai/lib/AssistantStream'
+import { CorporateServeUserType, VALID_CORPORATE_SERVE_USER_TYPES } from 'lib/types'
 
 // dummy comment for commit
 
@@ -39,10 +40,19 @@ export async function POST(req: Request) {
   // Parse the request body
   const input: {
     threadId: string | null
-    message: string
+    message: string,
+    data: {
+      userType?: CorporateServeUserType | null,
+      userID?: string | null
+    }
   } = await req.json()
   console.log(`[CampusAssistant] User message: ${input.message}`)
 
+  // not doing any validation here for now
+  let userType: CorporateServeUserType = input.data.userType || "student"
+  const userID = input.data.userID || null
+  console.log(`[CampusAssistant] UserType: ${userType} UserID: ${userID}`)
+    
   // Create a thread if needed
   const threadId = input.threadId ?? (await openai.beta.threads.create({})).id
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,17 @@ import { Chat } from '@/components/chat'
 
 export const runtime = 'edge'
 
-export default function IndexPage() {
-  const id = nanoid()
+export interface IndexPageProps {
+  params: {
+    userType: string,
+    userID: string
+  }
+}
 
-  return <Chat id={id} />
+export default function IndexPage({ params }: IndexPageProps) {
+  const id = nanoid()
+  const userType = params.userType
+  const userID = params.userID
+
+  return <Chat id={id} additionalData={{userType: userType, userID: userID}} />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,8 @@ export const runtime = 'edge'
 
 export interface IndexPageProps {
   params: {
-    userType: string,
-    userID: string
+    userType?: string | null,
+    userID?: string | null
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,17 +3,18 @@ import { Chat } from '@/components/chat'
 
 export const runtime = 'edge'
 
-export interface IndexPageProps {
-  params: {
-    userType?: string | null,
-    userID?: string | null
-  }
-}
+const getQueryParamAsString = (param: string | string[] | undefined): string | null =>
+  Array.isArray(param) ? param[0] : param ?? null;
 
-export default function IndexPage({ params }: IndexPageProps) {
-  const id = nanoid()
-  const userType = params.userType
-  const userID = params.userID
+export default function IndexPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const id = nanoid();
 
-  return <Chat id={id} additionalData={{userType: userType, userID: userID}} />
+  const userType = getQueryParamAsString(searchParams['userType']);
+  const userID = getQueryParamAsString(searchParams['userID']);
+
+  return <Chat id={id} additionalData={{ userType, userID }} />;
 }

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -18,6 +18,7 @@ export interface ChatPanelProps
   > {
   id?: string
   isLoading: boolean
+  additionalData?: Record<any, any>
 }
 
 export function ChatPanel({
@@ -27,8 +28,11 @@ export function ChatPanel({
   isLoading,
   input,
   setInput,
-  messages
+  messages,
+  additionalData
 }: ChatPanelProps) {
+  const userType = additionalData?.userType
+  const userID = additionalData?.userID
   return (
     <div className="fixed inset-x-0 bottom-0 bg-corpoBackground">
       {/* <ButtonScrollToBottom /> */}
@@ -48,11 +52,14 @@ export function ChatPanel({
         <div className="space-y-4 border-t bg-corpoChatPanelBackground px-4 py-2 shadow-lg sm:rounded-t-xl sm:border md:py-4">
           <PromptForm
             onSubmit={async value => {
-              await append({
-                id,
-                content: value,
-                role: 'user'
-              })
+              await append(
+                {
+                  id,
+                  content: value,
+                  role: 'user'
+                },
+                { data: { userType: userType, userID: userID } }
+              )
             }}
             input={input}
             setInput={setInput}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -26,8 +26,8 @@ export interface ChatProps extends React.ComponentProps<'div'> {
   initialMessages?: Message[]
   id?: string
   additionalData: {
-    userType?: string
-    userID?: string
+    userType?: string | null
+    userID?: string | null
   }
 }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -25,7 +25,7 @@ const IS_PREVIEW = process.env.VERCEL_ENV === 'preview'
 export interface ChatProps extends React.ComponentProps<'div'> {
   initialMessages?: Message[]
   id?: string
-  additionalData: {
+  additionalData?: {
     userType?: string | null
     userID?: string | null
   }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -25,9 +25,13 @@ const IS_PREVIEW = process.env.VERCEL_ENV === 'preview'
 export interface ChatProps extends React.ComponentProps<'div'> {
   initialMessages?: Message[]
   id?: string
+  additionalData: {
+    userType?: string
+    userID?: string
+  }
 }
 
-export function Chat({ id, initialMessages, className }: ChatProps) {
+export function Chat({ id, initialMessages, className, additionalData }: ChatProps) {
   const [previewToken, setPreviewToken] = useLocalStorage<string | null>(
     'ai-token',
     null
@@ -66,6 +70,7 @@ export function Chat({ id, initialMessages, className }: ChatProps) {
         messages={messages}
         input={input}
         setInput={setInput}
+        additionalData={additionalData}
       />
 
       <Dialog open={previewTokenDialog} onOpenChange={setPreviewTokenDialog}>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,9 @@ export interface Chat extends Record<string, any> {
   sharePath?: string // Refactor to use RLS
 }
 
+export const VALID_CORPORATE_SERVE_USER_TYPES = ["student", "teacher", "admin"]
+export type CorporateServeUserType = 'student' | 'teacher' | 'admin'
+
 export type ServerActionResult<Result> = Promise<
   | Result
   | {

--- a/public/embed.js
+++ b/public/embed.js
@@ -3,6 +3,8 @@
   // const config = window.embeddedChatbotConfig || {};
   // const chatbotId = config.chatbotId || document.currentScript.getAttribute('chatbotId');
   // const domain = config.domain || document.currentScript.getAttribute('domain');
+  const userType = document.currentScript.getAttribute('userType') || 'student';
+  const userID = document.currentScript.getAttribute('userID') || null;
 
   // if (!chatbotId || !domain) {
   //   console.error('Chatbot ID and domain are required for embedding.');
@@ -51,7 +53,7 @@
 
   // Create iframe
   const iframe = document.createElement('iframe');
-  iframe.src = "https://vercel-ai-chatbot-with-supabase-xaeb.vercel.app";
+  iframe.src = `https://vercel-ai-chatbot-with-supabase-xaeb.vercel.app?userType=${userType}&userID=${userID}`;
   iframe.id = 'campus-assistant-chatbot-xaeb-iframe';
   iframe.style.cssText = `
     position: fixed;


### PR DESCRIPTION
[Demo it here](https://vercel-ai-chatbot-with-supabase-xaeb-3l1npngv7.vercel.app).

* You can now specify two new url params in our chatbot URL — `userType` and `userID`. 
* This is safe to deploy because with an empty `userID`, nothing happens. `userType` defaults to "student"
* When `userID` _is_ specified, additional instructions are sent to the LLM with every run. This is so that the LLM has different instructions for different students / teachers running the chatbot simultaneously.
* Additional instructions are pretty barebones for now; we'll update the assistant instructions to not ask for student ID / name upfront and provide it programmatically. 